### PR TITLE
bug fix s0 puls kwh teller

### DIFF
--- a/esphome/components/DSZ12D.yml
+++ b/esphome/components/DSZ12D.yml
@@ -98,3 +98,4 @@ sensor:
     lambda: return id(total_kwh_pulses);
     accuracy_decimals: 0
     internal: True
+

--- a/esphome/components/LEM022SJ.yml
+++ b/esphome/components/LEM022SJ.yml
@@ -98,3 +98,4 @@ sensor:
     lambda: return id(total_kwh_pulses);
     accuracy_decimals: 0
     internal: True
+    

--- a/esphome/components/LEM022SJ.yml
+++ b/esphome/components/LEM022SJ.yml
@@ -56,7 +56,7 @@ sensor:
     name:  "Actuele energie"
     id: actual_power
     icon: "mdi:flash"
-    internal_filter: ${impulslengte} 
+#    internal_filter: ${impulslengte} 
     accuracy_decimals: 0 #3
     unit_of_measurement:  "W" #'kW'
     state_class: measurement

--- a/esphome/components/kwhpuls.yml
+++ b/esphome/components/kwhpuls.yml
@@ -61,7 +61,7 @@ sensor:
     name:  "Actuele energie"
     id: actual_power
     icon: "mdi:flash"
-    internal_filter: ${impulslengte} 
+#    internal_filter: ${impulslengte} 
     accuracy_decimals: 0 #3
     unit_of_measurement:  "W" #'kW'
     state_class: measurement

--- a/esphome/components/kwhpuls.yml
+++ b/esphome/components/kwhpuls.yml
@@ -103,3 +103,4 @@ sensor:
     lambda: return id(total_kwh_pulses);
     accuracy_decimals: 0
     internal: True
+

--- a/esphome/components/s0-watermeter.yaml
+++ b/esphome/components/s0-watermeter.yaml
@@ -104,3 +104,4 @@ sensor:
     accuracy_decimals: 0
     lambda: return id(total_water_pulses);
     internal: True
+    

--- a/esphome/components/s0-watermeter.yaml
+++ b/esphome/components/s0-watermeter.yaml
@@ -64,7 +64,7 @@ sensor:
 #------------------------# Watermeter #------------------------#
 # ⬇ watermeter pulsen ⬇ #
   - platform: pulse_counter
-    pin: D2
+    pin: D5
     id: watermeter_pulse
     name: "watermeter pulse"
     state_class: measurement


### PR DESCRIPTION
bug fix s0 puls kwh teller

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  nl
  Je bent geweldig! Bedankt voor je bijdrage aan ons project!
   VERWIJDER GEEN TEKST van dit sjabloon! (tenzij geïnstrueerd).
-->
## Wat implementeert/repareert dit? 

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.

  NL
  Als uw PR een belangrijke wijziging bevat voor bestaande gebruikers, is dit belangrijk
   om ze te vertellen wat er kapot gaat, hoe ze het weer kunnen laten werken en waarom we dit hebben gedaan.
   Dit stuk tekst wordt gepubliceerd met de release-opmerkingen, dus het helpt als u
   schrijf het naar onze gebruikers, niet naar ons.
   Opmerking: verwijder deze sectie als deze PR GEEN belangrijke wijziging is.
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.

  nl
   Beschrijf hier het grote geheel van uw wijzigingen om aan de
   beheerders waarom we dit pull-verzoek moeten accepteren. Als het een bug oplost
   of een functieverzoek oplost, zorg er dan voor dat u naar dat probleem of die discussie linkt
   in de rubriek aanvullende informatie.
-->


## Soorten wijzigingen 
<!--
  What type of change does your PR introduce to the S0tool?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.

  nl
  Wat voor soort verandering introduceert uw PR in de code van de S0tool?
   LET OP: Gelieve slechts 1 aan te vinken! doos!
   Als uw PR vereist dat meerdere vakjes worden aangevinkt, zult u dat waarschijnlijk moeten doen
   splits het op in meerdere PR's. Dit maakt het eenvoudiger en sneller om code te beoordelen.
-->

- [X] Bugfix (vaste wijziging die een probleem verhelpt)
- [ ] Nieuwe functie (bedankt!)
- [ ] Breaking change (reparatie/functie waardoor bestaande functionaliteit kapot gaat)
- [ ] Ander


## Test Omgeving

- [ ] Watermeter
- [X] S0 teller
- [ ] ESPHome versie ````yaml # v202 ```
- [ ] Home Assistant versie ````yaml # v202 ```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.

  nl
  Details zijn belangrijk en helpen beheerders bij het verwerken van uw PR.
   Zorg ervoor dat u aanvullende gegevens invult, indien van toepassing.
-->

- Deze PR repareert of sluit het probleem: fixes #
- Deze PR is gerelateerd aan een probleem of discussie:
- Link naar pull-aanvraag voor documentatie:

## Voorbeeld invoer voor  `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.

  nl
  Door een configuratiefragment aan te leveren, wordt het voor een onderhouder gemakkelijker om te testen
   jouw PR. Bovendien geeft het voor nieuwe integraties een indruk van hoe
   de configuratie eruit zou zien.
   Opmerking: verwijder deze sectie als deze PR geen voorbeeldinvoer heeft.
-->

```yaml
# Example configuration.yaml

```

## Checklijst:
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  nl
  Zet een 'x' in de vakjes die van toepassing zijn. Deze kunt u ook achteraf invullen
   het maken van de PR. Als u twijfelt over een van hen, aarzel dan niet om het te vragen.
   We zijn hier om te helpen! Dit is slechts een herinnering aan wat we gaan bekijken
   voor voordat u uw code samenvoegt.
-->

  - [ ] De codewijziging is getest en werkt lokaal.
  - [ ] De codewijziging is nog niet getest.
  
Als door de gebruiker zichtbare functionaliteit of configuratievariabelen worden toegevoegd/gewijzigd :
  - [ ] Documentatie toegevoegd/bijgewerkt in de readme file.
  - [ ] Documentatie toegevoegd/bijgewerkt voor de webpagina [www.huizebruin.nl] of [docs-flashpagina]

<!--
  Thank you for contributing <3

  nl
  Bedankt voor je bijdrage <3
-->

[docs-flashpagina]: https://huizebruin.github.io/s0tool/

