### PR TITLE
update to V23.04.30

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,9 +222,12 @@ This can be done by the ESPHome dashboard by now.
 
 Have fun with this tool.<br>
 Any additions / improvements <br> may be made via <b>[Pull requests](https://github.com/huizebruin/s0tool/pulls)</b> be supplemented.<br> 
-Or via<b>[issues](https://github.com/huizebruin/s0tool/issues) </b> requested or added.
-<br><br><b>
-Wobbe from Huizebruin.nl</b>
+Or via<b> [issues](https://github.com/huizebruin/s0tool/issues) </b> requested or added.
+<br><br><br><b>
+Wobbe </b><br>
+From <a href="https://www.Huizebruin.nl" rel="noreferer, ,noopener" target="_blank">Huizebruin.nl</a>
+
+Do you like my work ?  [![](https://img.shields.io/badge/send%20me%20a%20small%20gift-paypal-blue.svg?style=flat-square)](https://paypal.me/huizebruin) 
 <br><br>
 For more information and connection diagrams, etc., take a look at the [website](https://www.huizebruin.nl/home-assistant/wat-is-de-s0tool/).
 ***
@@ -237,6 +240,36 @@ Who else is working on this project : <br>
 ![GitHub contributors](https://img.shields.io/github/contributors/huizebruin/s0tool?style=plastic)<br>
 
 ****
+
+<h2 id="troubleshooting">Troubleshooting</h2>
+
+<h3 id="drivers">USB Serial Drivers</h3>
+<p>
+  If the serial port is not showing up, your computer might be missing the
+  drivers for the USB serial chip used in your ESP device. These drivers
+  work for most ESP devices:
+</p>
+  <ul>
+  <li>
+    CP2102 (square chip):
+    <a href="https://www.silabs.com/products/development-tools/software/usb-to-uart-bridge-vcp-drivers" rel="noreferer, ,noopener" target="_blank">driver</a>
+  </li>
+  <li>
+    CH341:
+    <a href="https://github.com/nodemcu/nodemcu-devkit/tree/master/Drivers" rel="noreferer, ,noopener" target="_blank">driver</a>
+  </li>
+  <li>
+    CH340:
+    <a href="https://sparks.gogo.co.nz/ch340.html" rel="noreferer, ,noopener" target="_blank">driver</a>
+  </li>
+  </ul>
+<br>
+
+
+
+
+
+
 
 ## License
 
@@ -253,6 +286,10 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 ***
 
 <a href="https://tc.tradetracker.net/?c=27&amp;m=39668&amp;a=385034&amp;r=&amp;u=" target="_blank" rel="sponsored nofollow">Make money with your site. Start now, sign up here.</a>
+<div style="text-align:center;font-size:13px;">
+      <hr>
+      <a href="https://esphome.github.io/esp-web-tools/" target="_blank" style="color:#aaa;">S0tool Installer powered by ESP Web Tools</a>
+    </div>
 
 
 

--- a/esphome/components/DSZ12D.yml
+++ b/esphome/components/DSZ12D.yml
@@ -39,15 +39,16 @@ number:
 binary_sensor:
  #------------------------# kwh #------------------------#
   - platform: gpio
-    id: internal_pulse_counter2
-    name: Pulse Sensor kwh
+    id: kwh_sensor_status
+    name: kWh sensor status
+    internal: False
     pin:
       number: D5
       mode:
         input: true
     on_press:
       - then:
-          lambda: id(total_kwh_pulses) += 1;       
+          lambda: id(total_kwh_pulses) += 1;        
 #------------------------# Kwh meter S0 poort 1 #------------------------#
 sensor:
 # ⬇ kwh meter s0 ⬇ #

--- a/esphome/components/LEM022SJ.yml
+++ b/esphome/components/LEM022SJ.yml
@@ -39,15 +39,16 @@ number:
 binary_sensor:
  #------------------------# kwh #------------------------#
   - platform: gpio
-    id: internal_pulse_counter2
-    name: Pulse Sensor kwh
+    id: kwh_sensor_status
+    name: kWh sensor status
+    internal: False
     pin:
       number: D5
       mode:
         input: true
     on_press:
       - then:
-          lambda: id(total_kwh_pulses) += 1;       
+          lambda: id(total_kwh_pulses) += 1;        
 #------------------------# Kwh meter S0 poort 1 #------------------------#
 sensor:
 # ⬇ kwh meter s0 ⬇ #

--- a/esphome/components/basis.yaml
+++ b/esphome/components/basis.yaml
@@ -3,8 +3,8 @@
 # Bron File : https://github.com/huizebruin/s0tool/tree/main/esphome
 # © Huizebruin.nl
 substitutions:
-  vdate: "v23.02.29" 
-  date: "11-03-2023"
+  vdate: "v23.04.30" 
+  date: "07-04-2023"
   device_description: ${name} gemaakt door huizebruin.nl versie ${vdate} - ${date}.
 
 preferences:
@@ -15,7 +15,6 @@ improv_serial:
 wifi:
   # ssid: MyHomeNetwork
   # password: VerySafePassword
-
   ap:
     ssid: "s0tool"
     ap_timeout: 10s
@@ -23,20 +22,14 @@ wifi:
 web_server:
   port: 80
   
-# In combination with the `ap` this allows the user
-# to provision wifi credentials to the device.
 captive_portal:
-  # Optionally, preserve provisioned credentials
-  # over subsequent OTA updates.
 
 # ⬇ Enable logging ⬇ # 
 logger:
   level: INFO
   esp8266_store_log_strings_in_flash: false
 
-
 ota:
-
 #  ⬇ Enable time component voor reset elke nacht ⬇ #
 time:
   - platform: homeassistant

--- a/esphome/components/kwhpuls.yml
+++ b/esphome/components/kwhpuls.yml
@@ -44,8 +44,9 @@ number:
 binary_sensor:
  #------------------------# kwh #------------------------#
   - platform: gpio
-    id: internal_pulse_counter2
-    name: Pulse Sensor kwh
+    id: kwh_sensor_status
+    name: kWh sensor status
+    internal: False
     pin:
       number: D5
       mode:

--- a/esphome/components/s0-watermeter.yaml
+++ b/esphome/components/s0-watermeter.yaml
@@ -49,8 +49,9 @@ select:
 #------------------------# Watermeter #------------------------#
 binary_sensor:
   - platform: gpio
-    id: internal_pulse_counter
-    name: Pulse Sensor Water
+    id: water_sensor_status
+    name: Water sensor status
+    internal: False
     pin:
       number: D2
       inverted: true
@@ -59,7 +60,6 @@ binary_sensor:
     on_press:
       - then:
           lambda: id(total_water_pulses) += 1;  
-
 sensor:
 #------------------------# Watermeter #------------------------#
 # ⬇ watermeter pulsen ⬇ #

--- a/esphome/components/tcrt5000.yaml
+++ b/esphome/components/tcrt5000.yaml
@@ -26,29 +26,12 @@ globals:
     type: int
     restore_value: yes
     
-# select:
-#   # ⬇ water per m3 rate ⬇ #
-#   - platform: template
-#     name: "Pulsrate water per m3"
-#     id: Select_pulse_water
-#     optimistic: true
-#     options:
-#       - "0.0001"
-#       - "0.0005"
-#       - "0.001"       
-#     initial_option: "0.001"
-#     restore_value: yes
-#     on_value:
-#       then:
-#         - logger.log:
-#             format: "Chosen option: %s "
-#             args: ["x.c_str()"]
-
 #------------------------# Watermeter #------------------------#
 binary_sensor:
   - platform: gpio
-    id: internal_pulse_counter
-    name: Pulse Sensor Water
+    id: water_sensor_status
+    name: Water sensor status
+    internal: False
     pin:
       number: D2
       inverted: true
@@ -73,9 +56,6 @@ sensor:
     icon: "mdi:water-pump"
     filters:
       - multiply: 0.0167    
-#      lambda: return x * atof(id(Select_pulse_water).state.c_str()) * 1000;
-
-
 
 # ⬇ Totaal watermeter ⬇ #      
     total:

--- a/esphome/components/watermeter.yaml
+++ b/esphome/components/watermeter.yaml
@@ -49,9 +49,9 @@ select:
 #------------------------# Watermeter #------------------------#
 binary_sensor:
   - platform: gpio
-    id: internal_pulse_counter
-    name: Pulse Sensor Water
-    internal: True
+    id: water_sensor_status
+    name: Water sensor status
+    internal: False
     pin:
       number: D2
       inverted: true
@@ -59,7 +59,7 @@ binary_sensor:
         input: true
     on_press:
       - then:
-          lambda: id(total_water_pulses) += 1; 
+          lambda: id(total_water_pulses) += 1;  
 
 sensor:
 #------------------------# Watermeter #------------------------#

--- a/esphome/components/watermeter_flux.yaml
+++ b/esphome/components/watermeter_flux.yaml
@@ -45,8 +45,9 @@ number:
 #------------------------# Watermeter #------------------------#
 binary_sensor:
   - platform: gpio
-    id: internal_pulse_counter
-    name: Pulse Sensor Water
+    id: water_sensor_status
+    name: Water sensor status
+    internal: False
     pin:
       number: D2
       inverted: true
@@ -54,8 +55,7 @@ binary_sensor:
         input: true
     on_press:
       - then:
-          lambda: id(total_water_pulses) += 1;  
-
+          lambda: id(total_water_pulses) += 1;
 sensor:
 #------------------------# Watermeter #------------------------#
 # ⬇ watermeter pulsen ⬇ #

--- a/static/index.md
+++ b/static/index.md
@@ -158,7 +158,7 @@ For problems <b>[issues](https://github.com/huizebruin/s0tool/issues) . </b>
 Wobbe </b><br>
 From Huizebruin.nl
 
-Do you like my work ?  [![](https://img.shields.io/badge/send%20me%20a%20small%20gift-paypal-blue.svg?style=flat-square)](https://paypal.me/huizebruin) 
+Do you like my work ?<br>  [![](https://img.shields.io/badge/send%20me%20a%20small%20gift-paypal-blue.svg?style=flat-square)](https://paypal.me/huizebruin) 
 
 <br><br>
 For more information about the S0tool look at my (Dutch) [website](https://www.huizebruin.nl/home-assistant/wat-is-de-s0tool/).
@@ -176,7 +176,7 @@ THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR I
 ***
 
 <br>
-<div style="text-align:center;font-size:11px;">
+<div style="text-align:center;font-size:14px;">
       <hr>
       <a href="https://esphome.github.io/esp-web-tools/" target="_blank" style="color:#aaa;">S0tool Installer powered by ESP Web Tools</a>
     </div>


### PR DESCRIPTION
* Puls sensor kWh hernoemd naar kWh sensor status
* Puls sensor water hernoemd naar water sensor status
* Beide nu weer te volgen via de web interface en Home Assistant, om te volgen of je pulsen binnen krijgt vanaf de poort D2 of D5.
* Readme en flash pagina bijgewerkt.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  nl
  Je bent geweldig! Bedankt voor je bijdrage aan ons project!
   VERWIJDER GEEN TEKST van dit sjabloon! (tenzij geïnstrueerd).
-->
## Wat implementeert/repareert dit? 

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.

  NL
  Als uw PR een belangrijke wijziging bevat voor bestaande gebruikers, is dit belangrijk
   om ze te vertellen wat er kapot gaat, hoe ze het weer kunnen laten werken en waarom we dit hebben gedaan.
   Dit stuk tekst wordt gepubliceerd met de release-opmerkingen, dus het helpt als u
   schrijf het naar onze gebruikers, niet naar ons.
   Opmerking: verwijder deze sectie als deze PR GEEN belangrijke wijziging is.
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.

  nl
   Beschrijf hier het grote geheel van uw wijzigingen om aan de
   beheerders waarom we dit pull-verzoek moeten accepteren. Als het een bug oplost
   of een functieverzoek oplost, zorg er dan voor dat u naar dat probleem of die discussie linkt
   in de rubriek aanvullende informatie.
-->


## Soorten wijzigingen 
<!--
  What type of change does your PR introduce to the S0tool?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.

  nl
  Wat voor soort verandering introduceert uw PR in de code van de S0tool?
   LET OP: Gelieve slechts 1 aan te vinken! doos!
   Als uw PR vereist dat meerdere vakjes worden aangevinkt, zult u dat waarschijnlijk moeten doen
   splits het op in meerdere PR's. Dit maakt het eenvoudiger en sneller om code te beoordelen.
-->

- [X] Bugfix (vaste wijziging die een probleem verhelpt)
- [ ] Nieuwe functie (bedankt!)
- [ ] Breaking change (reparatie/functie waardoor bestaande functionaliteit kapot gaat)
- [ ] Ander


## Test Omgeving

- [X] Watermeter
- [X] S0 teller
- [X] ESPHome versie ````yaml # v2023.3.X ```
- [X] Home Assistant versie ````yaml # v2023.3.X ```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.

  nl
  Details zijn belangrijk en helpen beheerders bij het verwerken van uw PR.
   Zorg ervoor dat u aanvullende gegevens invult, indien van toepassing.
-->

- Deze PR repareert of sluit het probleem: fixes #
- Deze PR is gerelateerd aan een probleem of discussie:
- Link naar pull-aanvraag voor documentatie:

## Voorbeeld invoer voor  `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.

  nl
  Door een configuratiefragment aan te leveren, wordt het voor een onderhouder gemakkelijker om te testen
   jouw PR. Bovendien geeft het voor nieuwe integraties een indruk van hoe
   de configuratie eruit zou zien.
   Opmerking: verwijder deze sectie als deze PR geen voorbeeldinvoer heeft.
-->

```yaml
# Example configuration.yaml

```

## Checklijst:
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  nl
  Zet een 'x' in de vakjes die van toepassing zijn. Deze kunt u ook achteraf invullen
   het maken van de PR. Als u twijfelt over een van hen, aarzel dan niet om het te vragen.
   We zijn hier om te helpen! Dit is slechts een herinnering aan wat we gaan bekijken
   voor voordat u uw code samenvoegt.
-->

  - [X] De codewijziging is getest en werkt lokaal.
  - [ ] De codewijziging is nog niet getest.
  
Als door de gebruiker zichtbare functionaliteit of configuratievariabelen worden toegevoegd/gewijzigd :
  - [X] Documentatie toegevoegd/bijgewerkt in de readme file.
  - [X] Documentatie toegevoegd/bijgewerkt voor de webpagina [www.huizebruin.nl] of [docs-flashpagina]

<!--
  Thank you for contributing <3

  nl
  Bedankt voor je bijdrage <3
-->

[docs-flashpagina]: https://huizebruin.github.io/s0tool/

