### PR TITLE
Fix logger argument to use std::to_string(x)

### DIFF
--- a/esphome/components/gaspuls.yaml
+++ b/esphome/components/gaspuls.yaml
@@ -53,7 +53,7 @@ select:
       then:
         - logger.log:
             format: "Chosen option: %s "
-            args: ["x.c_str()"]
+            args: ["std::to_string(x)"]
 
 number:
   - platform: template

--- a/esphome/components/kwhpuls-resistor.yml
+++ b/esphome/components/kwhpuls-resistor.yml
@@ -40,7 +40,7 @@ number:
       then:
         - logger.log:
             format: "Chosen option: %s "
-            args: ["x.c_str()"]
+            args: ["std::to_string(x)"]
 
 binary_sensor:
 #------------------------# kwh #------------------------#

--- a/esphome/components/kwhpuls.yml
+++ b/esphome/components/kwhpuls.yml
@@ -40,7 +40,7 @@ number:
       then:
         - logger.log:
             format: "Chosen option: %s "
-            args: ["x.c_str()"]
+            args: ["std::to_string(x)"]
 
 binary_sensor:
 #------------------------# kwh #------------------------#
@@ -61,7 +61,7 @@ binary_sensor:
 sensor:
 # ⬇ kwh meter s0 ⬇ #
   - platform: pulse_meter
-    pin: 
+    pin:
       number: D5
       allow_other_uses: true
     name:  "Actuele energie"

--- a/esphome/components/s0-watermeter.yaml
+++ b/esphome/components/s0-watermeter.yaml
@@ -45,7 +45,7 @@ select:
       then:
         - logger.log:
             format: "Chosen option: %s "
-            args: ["x.c_str()"]
+            args: ["std::to_string(x)"]
 
 #------------------------# Watermeter #------------------------#
 binary_sensor:

--- a/esphome/components/sdm72d.yml
+++ b/esphome/components/sdm72d.yml
@@ -40,7 +40,7 @@ number:
       then:
         - logger.log:
             format: "Chosen option: %s "
-            args: ["x.c_str()"]
+            args: ["std::to_string(x)"]
 
 binary_sensor:
 #------------------------# kwh #------------------------#

--- a/esphome/components/water-resistor.yaml
+++ b/esphome/components/water-resistor.yaml
@@ -44,7 +44,7 @@ select:
       then:
         - logger.log:
             format: "Chosen option: %s "
-            args: ["x.c_str()"]
+            args: ["std::to_string(x)"]
 
 #------------------------# Watermeter #------------------------#
 binary_sensor:

--- a/esphome/components/watermeter.yaml
+++ b/esphome/components/watermeter.yaml
@@ -44,7 +44,7 @@ select:
       then:
         - logger.log:
             format: "Chosen option: %s "
-            args: ["x.c_str()"]
+            args: ["std::to_string(x)"]
 
 #------------------------# Watermeter #------------------------#
 binary_sensor:

--- a/esphome/components/wsz15d32a.yml
+++ b/esphome/components/wsz15d32a.yml
@@ -40,7 +40,7 @@ number:
       then:
         - logger.log:
             format: "Chosen option: %s "
-            args: ["x.c_str()"]
+            args: ["std::to_string(x)"]
 
 binary_sensor:
  #------------------------# kwh #------------------------#


### PR DESCRIPTION
Replaces usage of x.c_str() with std::to_string(x) in logger.log calls across multiple component YAML files to ensure correct string formatting of numeric values.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  nl
  Je bent geweldig! Bedankt voor je bijdrage aan ons project!
   VERWIJDER GEEN TEKST van dit sjabloon! (tenzij geïnstrueerd).
-->
## What does this implement/fix? / Wat implementeert/repareert dit? 

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.

  NL
  Als uw PR een belangrijke wijziging bevat voor bestaande gebruikers, is dit belangrijk
   om ze te vertellen wat er kapot gaat, hoe ze het weer kunnen laten werken en waarom we dit hebben gedaan.
   Dit stuk tekst wordt gepubliceerd met de release-opmerkingen, dus het helpt als u
   schrijf het naar onze gebruikers, niet naar ons.
   Opmerking: verwijder deze sectie als deze PR GEEN belangrijke wijziging is.
-->

## Proposed change / Voorgestelde verandering.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.

  nl
   Beschrijf hier het grote geheel van uw wijzigingen om aan de
   beheerders waarom we dit pull-verzoek moeten accepteren. Als het een bug oplost
   of een functieverzoek oplost, zorg er dan voor dat u naar dat probleem of die discussie linkt
   in de rubriek aanvullende informatie.
-->


## Types of changes / Soorten wijzigingen .
<!--
  What type of change does your PR introduce to the S0tool?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.

  nl
  Wat voor soort verandering introduceert uw PR in de code van de S0tool?
   LET OP: Gelieve slechts 1 aan te vinken! doos!
   Als uw PR vereist dat meerdere vakjes worden aangevinkt, zult u dat waarschijnlijk moeten doen
   splits het op in meerdere PR's. Dit maakt het eenvoudiger en sneller om code te beoordelen.
-->

- [ ] Bugfix (fixed change that fixes an issue) / Bugfix (vaste wijziging die een probleem verhelpt)
- [ ] New feature (thanks!) / Nieuwe functie (bedankt!)
- [ ] Breaking change (repair/feature that breaks existing functionality) / Breaking change (reparatie/functie waardoor bestaande functionaliteit kapot gaat)
- [ ] Other / Ander
- [ ] Website of github readme file update
- [ ] Github workflows

## Test Environment / Test Omgeving

- [ ] Water meter / Watermeter
- [ ] S0 counter / S0 teller
- [ ] ESPHome version / ESPHome versie ````yaml # v202 ```
- [ ] Home Assistant version / Home Assistant versie ````yaml # v202 ```
- [ ] Website of github readme file update

## Additional information / Aanvullende info

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.

  nl
  Details zijn belangrijk en helpen beheerders bij het verwerken van uw PR.
   Zorg ervoor dat u aanvullende gegevens invult, indien van toepassing.
-->

- This PR fixes or closes the issue: fixes / Deze PR repareert of sluit het probleem: fixes #
- This PR is related to an issue or discussion / Deze PR is gerelateerd aan een probleem of discussie:
- Link to pull request for documentation / Link naar pull-aanvraag voor documentatie:

## Supplying a configuration snippet / Voorbeeld invoer voor  `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.

  nl
  Door een configuratiefragment aan te leveren, wordt het voor een onderhouder gemakkelijker om te testen
   jouw PR. Bovendien geeft het voor nieuwe integraties een indruk van hoe
   de configuratie eruit zou zien.
   Opmerking: verwijder deze sectie als deze PR geen voorbeeldinvoer heeft.
-->

```yaml
# Example configuration.yaml

```

## Checklist / Checklijst:
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  nl
  Zet een 'x' in de vakjes die van toepassing zijn. Deze kunt u ook achteraf invullen
   het maken van de PR. Als u twijfelt over een van hen, aarzel dan niet om het te vragen.
   We zijn hier om te helpen! Dit is slechts een herinnering aan wat we gaan bekijken
   voor voordat u uw code samenvoegt.
-->

  - [ ] The code change has been tested and works locally / De codewijziging is getest en werkt lokaal.
  - [ ] The code change has not yet been tested / De codewijziging is nog niet getest.
  
If user-visible functionality or configuration variables are added/modified / Als door de gebruiker zichtbare functionaliteit of configuratievariabelen worden toegevoegd/gewijzigd :
  - [ ] Documentation added/updated in the readme file / Documentatie toegevoegd/bijgewerkt in de readme file.
  - [ ] Added/updated documentation for the web page / Documentatie toegevoegd/bijgewerkt voor de webpagina (s0tool.nl)[https://s0tool.nl].

<!--
  Thank you for contributing <3

  nl
  Bedankt voor je bijdrage <3
-->



