### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,8 @@ jobs:
 
   consolidate:
     name: Consolidate firmwares 🚀
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     needs: build
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/huizebruin/s0tool/security/code-scanning/4](https://github.com/huizebruin/s0tool/security/code-scanning/4)

To fix the problem, add a `permissions` block to the `consolidate` job in `.github/workflows/build.yml`. This block should specify the minimal permissions required for the job. Since the job only needs to read repository contents (for checkout) and does not need to write to the repository or access other privileged resources, the minimal starting point is `contents: read`. This change should be made directly under the `consolidate:` job definition, before the `runs-on:` key.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * tightened CI permissions by setting the build consolidation step to use a read-only token for repository contents, improving security posture without changing workflow behavior or release output
  * no impact to application features or user experience; processes continue to run as before with more restrictive access controls

<!-- end of auto-generated comment: release notes by coderabbit.ai -->