### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,5 +1,9 @@
 ---
 name: Stale
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
 
 # yamllint disable-line rule:truthy
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/huizebruin/s0tool/security/code-scanning/3](https://github.com/huizebruin/s0tool/security/code-scanning/3)

To fix the problem, add a `permissions` block to the workflow to explicitly specify the minimal set of permissions required for the `actions/stale` action to function. According to the [actions/stale documentation](https://github.com/actions/stale#permissions), the action requires `issues: write`, `pull-requests: write`, and `contents: write` permissions. The best way to do this is to add a `permissions` block at the top level of the workflow (after the `name` field and before `on:`), so it applies to all jobs in the workflow. No changes to the steps or other workflow logic are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Stale workflow permissions to grant the automation token write access to contents, issues, and pull requests, improving reliability of stale issue and PR management.
  * No changes to workflow triggers, messages, or steps; behavior remains the same for users, with enhanced consistency in automatic labeling and closing of inactive items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->