### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/labels.yaml
+++ b/.github/workflows/labels.yaml
@@ -12,6 +12,9 @@ on:
 jobs:
   labels:
     name: ♻️ Sync labels
+    permissions:
+      contents: read
+      issues: write
     runs-on: ubuntu-latest
     steps:
       - name: ⤵️ Check out code from GitHub


### PR DESCRIPTION
Potential fix for [https://github.com/huizebruin/s0tool/security/code-scanning/2](https://github.com/huizebruin/s0tool/security/code-scanning/2)

To fix the problem, add a `permissions` block to the job definition for `labels` in `.github/workflows/labels.yaml`. The minimal required permissions for the label syncer action are `contents: read` (to read repository contents) and `issues: write` (to update labels, which are part of issues). The `permissions` block should be added directly under the job name (`name: ♻️ Sync labels`) and before `runs-on: ubuntu-latest`. No other changes are needed, and no imports or additional definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow permissions related to automated label management.
  * No user-facing changes to app features, UI, performance, or data.
  * Infrastructure-only update; rollout is transparent across environments.
  * No action required from users or administrators.
  * Support processes for issue labeling continue to function as before.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->