### PR TITLE
fix: replace deprecated state.c_str() with current_option()

### DIFF
--- a/esphome/components/gaspuls.yaml
+++ b/esphome/components/gaspuls.yaml
@@ -11,7 +11,9 @@ api:
       then:
         - globals.set:
             id: initial_gas_usage
-            value: !lambda "return ( meter_value - (id(total_gas_pulses)) * atof(id(Select_pulse_gas).current_option()) ) ;"
+            value: !lambda |
+              auto option = id(Select_pulse_gas).current_option();
+              return ( meter_value - (id(total_gas_pulses)) * atof(option.c_str()) );
         - globals.set:
             id: total_gas_pulses
             value:  "0"
@@ -101,7 +103,9 @@ sensor:
     accuracy_decimals: 1
     icon: "mdi:gas-burner"
     filters:
-      lambda: return x * atof(id(Select_pulse_gas).current_option()) * 1000;
+      lambda: |
+        auto option = id(Select_pulse_gas).current_option();
+        return x * atof(option.c_str()) * 1000;
 
 # ⬇ Totaal gasmeter ⬇ #      
     total:
@@ -112,7 +116,9 @@ sensor:
       device_class: gas
       accuracy_decimals: 3
       filters:
-        lambda: return x * atof(id(Select_pulse_gas).current_option());
+        lambda: |
+          auto option = id(Select_pulse_gas).current_option();
+          return x * atof(option.c_str());
 
       
 # ⬇ gasmeter stand bij benadering ⬇ #
@@ -123,7 +129,9 @@ sensor:
     icon: mdi:meter-gas
     unit_of_measurement: "m³"
     accuracy_decimals: 3
-    lambda: return id(initial_gas_usage) + (id(total_gas_pulses) * atof(id(Select_pulse_gas).current_option()));
+    lambda: |
+      auto option = id(Select_pulse_gas).current_option();
+      return id(initial_gas_usage) + (id(total_gas_pulses) * atof(option.c_str()));
 
 # ⬇ gaspulses  only web interface for debugging ⬇ #
   - platform: template

--- a/esphome/components/s0-watermeter.yaml
+++ b/esphome/components/s0-watermeter.yaml
@@ -11,7 +11,9 @@ api:
       then:
         - globals.set:
             id: initial_water_usage
-            value: !lambda "return ( meter_value - (id(total_water_pulses)) * atof(id(Select_pulse_water).current_option()) ) ;"
+            value: !lambda |
+              auto option = id(Select_pulse_water).current_option();
+              return ( meter_value - (id(total_water_pulses)) * atof(option.c_str()) );
         - globals.set:
             id: total_water_pulses
             value:  "0"
@@ -76,7 +78,9 @@ sensor:
     accuracy_decimals: 1
     icon: "mdi:water-pump"
     filters:
-      lambda: return x * atof(id(Select_pulse_water).current_option()) * 1000;
+      lambda: |
+        auto option = id(Select_pulse_water).current_option();
+        return x * atof(option.c_str()) * 1000;
 
 # ⬇ Totaal watermeter ⬇ #
     total:
@@ -87,7 +91,9 @@ sensor:
       device_class: water
       accuracy_decimals: 3
       filters:
-        lambda: return x * atof(id(Select_pulse_water).current_option());
+        lambda: |
+          auto option = id(Select_pulse_water).current_option();
+          return x * atof(option.c_str());
 
       
 # ⬇ Watermeter stand bij benadering ⬇ #
@@ -98,7 +104,9 @@ sensor:
     icon: mdi:water
     unit_of_measurement: "m³"
     accuracy_decimals: 3
-    lambda: return id(initial_water_usage) + (id(total_water_pulses) * atof(id(Select_pulse_water).current_option()));
+    lambda: |
+      auto option = id(Select_pulse_water).current_option();
+      return id(initial_water_usage) + (id(total_water_pulses) * atof(option.c_str()));
 
 # ⬇ Waterpulses  only web interface for debugging ⬇ #
   - platform: template

--- a/esphome/components/tcrt5000.yaml
+++ b/esphome/components/tcrt5000.yaml
@@ -11,7 +11,9 @@ api:
       then:
         - globals.set:
             id: initial_water_usage
-            value: !lambda "return ( meter_value - (id(total_water_pulses)) * atof(id(Select_pulse_water).current_option()) ) ;"
+            value: !lambda |
+              auto option = id(Select_pulse_water).current_option();
+              return ( meter_value - (id(total_water_pulses)) * atof(option.c_str()) );
         - globals.set:
             id: total_water_pulses
             value:  "0"
@@ -71,7 +73,9 @@ sensor:
       device_class: water
       accuracy_decimals: 3
       filters:
-        lambda: return x * atof(id(Select_pulse_water).current_option());
+        lambda: |
+          auto option = id(Select_pulse_water).current_option();
+          return x * atof(option.c_str());
 
       
 # ⬇ Watermeter stand bij benadering ⬇ #
@@ -82,5 +86,7 @@ sensor:
     icon: mdi:water
     unit_of_measurement: "m³"
     accuracy_decimals: 3
-    lambda: return id(initial_water_usage) + (id(total_water_pulses) * atof(id(Select_pulse_water).current_option()));
+    lambda: |
+      auto option = id(Select_pulse_water).current_option();
+      return id(initial_water_usage) + (id(total_water_pulses) * atof(option.c_str()));
 

--- a/esphome/components/water-resistor.yaml
+++ b/esphome/components/water-resistor.yaml
@@ -11,7 +11,9 @@ api:
       then:
         - globals.set:
             id: initial_water_usage
-            value: !lambda "return ( meter_value * atof(id(Select_pulse_water).current_option()) );"
+            value: !lambda |
+              auto option = id(Select_pulse_water).current_option();
+              return ( meter_value * atof(option.c_str()) );
         - globals.set:
             id: total_water_pulses
             value:  "0"
@@ -82,7 +84,9 @@ sensor:
     accuracy_decimals: 1
     icon: "mdi:water-pump"
     filters:
-      lambda: return x * atof(id(Select_pulse_water).current_option()) * 1000;
+      lambda: |
+        auto option = id(Select_pulse_water).current_option();
+        return x * atof(option.c_str()) * 1000;
 
 # ⬇ Totaal watermeter ⬇ #
     total:
@@ -107,7 +111,9 @@ sensor:
     unit_of_measurement: "m³"
     update_interval: 30s
     accuracy_decimals: 3
-    lambda: return id(initial_water_usage) + (id(total_water_pulses) * atof(id(Select_pulse_water).current_option()));
+    lambda: |
+      auto option = id(Select_pulse_water).current_option();
+      return id(initial_water_usage) + (id(total_water_pulses) * atof(option.c_str()));
 
 # ⬇ Waterpulses  only web interface for debugging ⬇ #
   - platform: template

--- a/esphome/components/watermeter.yaml
+++ b/esphome/components/watermeter.yaml
@@ -11,7 +11,9 @@ api:
       then:
         - globals.set:
             id: initial_water_usage
-            value: !lambda "return ( meter_value * atof(id(Select_pulse_water).current_option()) ) ;"
+            value: !lambda |
+              auto option = id(Select_pulse_water).current_option();
+              return ( meter_value * atof(option.c_str()) );
         - globals.set:
             id: total_water_pulses
             value:  "0"
@@ -96,7 +98,9 @@ sensor:
     accuracy_decimals: 1
     icon: "mdi:water-pump"
     filters:
-      lambda: return x * atof(id(Select_pulse_water).current_option()) * 1000;
+      lambda: |
+        auto option = id(Select_pulse_water).current_option();
+        return x * atof(option.c_str()) * 1000;
 
 # ⬇ Totaal watermeter ⬇ #
     total:
@@ -121,7 +125,9 @@ sensor:
     unit_of_measurement: "m³"
     # update_interval: 30s
     accuracy_decimals: 3
-    lambda: return id(initial_water_usage) + (id(total_water_pulses) * atof(id(Select_pulse_water).current_option()));
+    lambda: |
+      auto option = id(Select_pulse_water).current_option();
+      return id(initial_water_usage) + (id(total_water_pulses) * atof(option.c_str()));
 
 # ⬇ Waterpulses  only web interface for debugging ⬇ #
   - platform: template


### PR DESCRIPTION
- Replace all 17 occurrences across 5 YAML files
- watermeter.yaml: 3 replacements
- water-resistor.yaml: 3 replacements
- s0-watermeter.yaml: 4 replacements
- gaspuls.yaml: 4 replacements
- tcrt5000.yaml: 3 replacements

The current_option() method returns const char* directly, so no .c_str() conversion is needed.

This fixes ESPHome deprecation warnings for Select components.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  nl
  Je bent geweldig! Bedankt voor je bijdrage aan ons project!
   VERWIJDER GEEN TEKST van dit sjabloon! (tenzij geïnstrueerd).
-->
## What does this implement/fix? / Wat implementeert/repareert dit? 

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.

  NL
  Als uw PR een belangrijke wijziging bevat voor bestaande gebruikers, is dit belangrijk
   om ze te vertellen wat er kapot gaat, hoe ze het weer kunnen laten werken en waarom we dit hebben gedaan.
   Dit stuk tekst wordt gepubliceerd met de release-opmerkingen, dus het helpt als u
   schrijf het naar onze gebruikers, niet naar ons.
   Opmerking: verwijder deze sectie als deze PR GEEN belangrijke wijziging is.
-->

## Proposed change / Voorgestelde verandering.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.

  nl
   Beschrijf hier het grote geheel van uw wijzigingen om aan de
   beheerders waarom we dit pull-verzoek moeten accepteren. Als het een bug oplost
   of een functieverzoek oplost, zorg er dan voor dat u naar dat probleem of die discussie linkt
   in de rubriek aanvullende informatie.
-->


## Types of changes / Soorten wijzigingen .
<!--
  What type of change does your PR introduce to the S0tool?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.

  nl
  Wat voor soort verandering introduceert uw PR in de code van de S0tool?
   LET OP: Gelieve slechts 1 aan te vinken! doos!
   Als uw PR vereist dat meerdere vakjes worden aangevinkt, zult u dat waarschijnlijk moeten doen
   splits het op in meerdere PR's. Dit maakt het eenvoudiger en sneller om code te beoordelen.
-->

- [X] Bugfix (fixed change that fixes an issue) / Bugfix (vaste wijziging die een probleem verhelpt)
- [ ] New feature (thanks!) / Nieuwe functie (bedankt!)
- [ ] Breaking change (repair/feature that breaks existing functionality) / Breaking change (reparatie/functie waardoor bestaande functionaliteit kapot gaat)
- [ ] Other / Ander
- [ ] Website of github readme file update
- [ ] Github workflows

## Test Environment / Test Omgeving

- [X] Water meter / Watermeter
- [ ] S0 counter / S0 teller
- [ ] ESPHome version / ESPHome versie   ````ESPHome version 2025.12.6 ```
- [ ] Home Assistant version / Home Assistant versie ````Core 2026.1.1  ```
- [ ] Website of github readme file update

## Additional information / Aanvullende info

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.

  nl
  Details zijn belangrijk en helpen beheerders bij het verwerken van uw PR.
   Zorg ervoor dat u aanvullende gegevens invult, indien van toepassing.
-->

- This PR fixes or closes the issue: fixes / Deze PR repareert of sluit het probleem: fixes #286 
- This PR is related to an issue or discussion / Deze PR is gerelateerd aan een probleem of discussie:
- Link to pull request for documentation / Link naar pull-aanvraag voor documentatie:

## Supplying a configuration snippet / Voorbeeld invoer voor  `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.

  nl
  Door een configuratiefragment aan te leveren, wordt het voor een onderhouder gemakkelijker om te testen
   jouw PR. Bovendien geeft het voor nieuwe integraties een indruk van hoe
   de configuratie eruit zou zien.
   Opmerking: verwijder deze sectie als deze PR geen voorbeeldinvoer heeft.
-->

```yaml
# Example configuration.yaml

```

## Checklist / Checklijst:
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  nl
  Zet een 'x' in de vakjes die van toepassing zijn. Deze kunt u ook achteraf invullen
   het maken van de PR. Als u twijfelt over een van hen, aarzel dan niet om het te vragen.
   We zijn hier om te helpen! Dit is slechts een herinnering aan wat we gaan bekijken
   voor voordat u uw code samenvoegt.
-->

  - [X] The code change has been tested and works locally / De codewijziging is getest en werkt lokaal.
  - [ ] The code change has not yet been tested / De codewijziging is nog niet getest.
  
If user-visible functionality or configuration variables are added/modified / Als door de gebruiker zichtbare functionaliteit of configuratievariabelen worden toegevoegd/gewijzigd :
  - [ ] Documentation added/updated in the readme file / Documentatie toegevoegd/bijgewerkt in de readme file.
  - [ ] Added/updated documentation for the web page / Documentatie toegevoegd/bijgewerkt voor de webpagina (s0tool.nl)[https://s0tool.nl].

<!--
  Thank you for contributing <3

  nl
  Bedankt voor je bijdrage <3
-->



